### PR TITLE
Adding tap recogniser to static map image

### DIFF
--- a/Showcase-iOS/Contact Us/View/ContactUsCollectionViewCell.swift
+++ b/Showcase-iOS/Contact Us/View/ContactUsCollectionViewCell.swift
@@ -49,6 +49,7 @@ class ContactUsCollectionViewCell: UICollectionViewCell {
         locationDescription.text = viewModel?.locationDescription
         populateStaticMap()
         styleView()
+        addTapRecogniserToStaticImage()
     }
     
     private func populateImageView(with imagePath: String) {
@@ -79,6 +80,17 @@ class ContactUsCollectionViewCell: UICollectionViewCell {
         email.setTitleColor(UIColor.DvtBlueColor, for: .normal)
         call.setTitleColor(UIColor.DvtBlueColor, for: .normal)
         navigate.setTitleColor(UIColor.DvtBlueColor, for: .normal)
+        
+    }
+    
+    private func addTapRecogniserToStaticImage() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(staticMapImageTapped(tapGestureRecognizer:)))
+        mapImage.isUserInteractionEnabled = true
+        mapImage.addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    @objc private func staticMapImageTapped(tapGestureRecognizer: UITapGestureRecognizer) {
+        viewModel?.navigate()
         
     }
 }


### PR DESCRIPTION
This PR adds a tap recogniser to static map image. On tapping the static map, app hands over navigation to the native map app.